### PR TITLE
Add German(european BOM)

### DIFF
--- a/BOM/voron_germany.md
+++ b/BOM/voron_germany.md
@@ -1,0 +1,111 @@
+# VORON BOM  
+
+### Frame  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| 2020 Extrusion - Black - 370mm                          | VB-FR-01-EXT1    | SMT Montagetechnik           | S1052020SCH                | 12  |
+| Cube Corner Bracket                                     | VB-FR-01-CB1     | SMT Montagetechnik           | S205VS202020               | 8   |
+
+
+### Linear Motion  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| Linear Shaft - 8mm - Hardened - 320mm                   | VB-LM-01-LS1     | Dold Mechatronik             | 70021-SZ1200               | 8   |
+| Linear Bearing (Single)                                 | VB-LM-01-LB1     | Dold Mechatronik             | 13110                      | 2   |
+| Linear Bearing (Double)                                 | VB-LM-01-LB2     | eBay(3dhamburg)              | 272125957622 (2-pack)      | 3   |
+| GT2 Belt - 6mm x 2mm pitch 1.5M long                    | VB-LM-01-GTB1    | eBay(ewin4may)               | 262622572138 (incl. 2 pulleys) | 2   |
+| GT2 Pulley - 20 tooth - 2mm pitch                       | VB-LM-01-GTP1    | eBay(ewin4may)               | see above                  | 2   |
+| NEMA 17 Linear Stepper TR8x8 300mm (with nut)           | VB-EL-01-LSM1    | eBay(wantaimotor)            | 182246605454               | 2   |
+| F695ZZ - Flanged Ball Bearing                           | VB-LM-01-BBF1    | eBay(kugellager-handloser)   | 371253693783               | 16  |
+
+### Electronics  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| NEMA 17 Stepper                                         | VB-EL-01-SM1     | eBay(stepperonline)          | 331440962687               | 2   |
+| Arduino MEGA2560 R3                                     | VB-EL-01-AM3     | Amazon                       | B0111ZSS2O (inkl. Arduino, LCD, 4xA4988, USB cable) | 1   |
+| RAMPs 1.4 SP                                            | VB-EL-01-RSP     | Amazon                       | see above                  | 1   |
+| LCD Controller Full Graphics                            | VB-EL-01-LCD     | Amazon                       | see above                  | 1   |
+| USB Cable                                               | VB-EL-01-USB     | Amazon                       | see above                  | 1   |
+| DRV8825 Drivers (set of 5)                              | VB-EL-01-DRV     | Amazon                       | B011FSW30A (pack of 5)     | 1   |
+| Endstop Microswitch (KW10 series, hole distance 6.5mm)  | VB-EL-01-ESS1    | eBay(roboter-bausatz)        | 172235491107               | 2   |
+| 12V PSU 16.7A                                           | VB-EL-01-PSU1    | Amazon                       | B0191H4QC0                 | 1   |
+| 250V 10A 3pin IEC320 C14 Inlet w/ fuse and switch       | VB-EL-01-ISW1    | Amazon                       | B01HJ9WUIO                 | 1   |
+| Bed Harness Connector - Molex                           | VB-EL-01-BHC1    | Mouser                       | 538-76650-0065 (2 pack)    | 1   |
+| Silicone Heater 110V 250W                               | VB-EL-01-BH1     | Filafarm                     |                            | 1   |
+| Bed Thermistor - M3 Hex Stud - EPOCS                    | VB-EL-01-TB1     | Filafarm (embedded in heater)|                            | 1   |
+| 110V SSR - Omron                                        | VB-EL-01-SSR1    | Filafarm                     |                            | 1   | 
+| 2 pin Dupont jumper wire (12V supply for Fan Exp Baord) | VB-EL-01-FXW1    | eBay(eckstein_komponente)    | 271970160475               | 1   |
+| RAMPs Fan Expansion board                               | VB-EL-01-RFX1    | eBay(3dprintparts)           | 282246251601               | 1   |
+| 2 pin Dupont Connector (female set)                     | VB-EL-01-DC3     | eBay(eckstein_komponente)    | 282194267142(set of 10)    | 1   |
+| 4 pin Dupont Connector (female set)                     | VB-EL-01-DC4     | eBay(eckstein_komponente)    | 282194267142(set of 5)     | 1   |
+| Header Pins (Long)                                      | VB-EL-01-HP4     | eBay(madtronicsde)           | 142050561554(set of 200)   | 1   |
+| Molex MicroFit3 3pin Plug Housing                       | VB-EL-01-MLX-H3  | Mouser                       | 538-43640-0301             | 1   |
+| Molex MicroFit3 3pin Receptacle                         | VB-EL-01-MLX-R3  | Mouser                       | 538-43645-0300             | 1   |
+| Molex MicroFit3 2pin Plug Housing                       | VB-EL-01-MLX-H2  | Mouser                       | 538-43640-0201             | 7   |
+| Molex MicroFit3 2pin Receptacle                         | VB-EL-01-MLX-R2  | Mouser                       | 538-43645-0200             | 7   |
+| Molex MicroFit3 Female Pin (20-24AWG)                   | VB-EL-01-MLX-FP1 | Mouser                       | 538-43030-0007             | 4   |
+| Molex MicroFit3 Female Pin (26-30AWG)                   | VB-EL-01-MLX-FP2 | Mouser                       | 538-43030-0010             | 13  |
+| Molex MicroFit3 Male Pin (20-24AWG)                     | VB-EL-01-MLX-MP1 | Mouser                       | 538-43031-0007             | 4   |
+| Molex MicroFit3 Male Pin (26-30AWG)                     | VB-EL-01-MLX-MP2 | Mouser                       | 538-43031-0010             | 13  |
+| Spade Connector (Female)                                | VB-EL-01-SPC-F   | eBay(future-light-distribution)| 161717048382(set of 50)  | 8   |
+| Spade Connector (Male)                                  | VB-EL-01-SPC-M   | eBay(future-light-distribution)| 161717048382(set of 50)  | 1   |
+| 20AWG Wire (Black) 9ft                                  | VB-EL-01-W20-B   | eBay(big-brother3)           | 160762832426 (1m)          | 3   |
+| 20AWG Wire (Red) 9ft                                    | VB-EL-01-W20-R   | eBay(big-brother3)           | 161934079342 (1m)          | 3   |
+| 20AWG Wire (Green) 3ft                                  | VB-EL-01-W20-G   | eBay(cable-parts24)          | 112187846482 (1m)          | 1   |
+| CAT5e Stranded Patch Cable wire (6ft)                   | VB-EL-01-CAT5    | eBay(*memoryking*)           | 361295942969 (3m)          | 1   |
+| Dupont Female Pin                                       | VB-EL-01-DPF1    | eBay(stoutwind-dot-de)       | 131887792253 (set of 25)   | 3   |
+| 80x80x10 case fan 12V                                   | VB-EL-01-F802    | eBay(conrad_electronic)      | 360991128809               | 1   |
+| 40x40x20 blower fan 12V                                 | VB-EL-01-F302    | Filafarm                     |                            | 1   |
+| Inductive Proximity Sensor                              | VB-EL-01-IPS1    | eBay(www-gerasit-de)         | 252314884820               | 1   |
+| 2M Ohm resistor (for inductive sensor)                  | VB-EL-01-R2M     | eBay(www_ewlicht_de)         | 371315154268 (set of 20)   | 1   |
+| C14 Power Cable (US)                                    | VB-EL-01-PC-US   | Amazon                       | B000XPSD0Q                 | 1   |
+
+### Electronics (Optional)  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| LED Strip                                               | VB-EL-01-LED1    | eBay(estar2013)              | 291906956725               | 1   |
+| Thermal Protection Fuse (120C)                          | VB-EL-01-TPF1    | eBay(job-elektronik)         | 271637435442               | 1   |
+
+### Extrusion  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| E3D Chimera Kit                                         | VB-EX-01-DHK1    | E3D-Online                   |                            | 1   |
+| NEMA 17 Stepper                                         | VB-EL-01-LSM1    | eBay(stepperonline)          | 331440962687               | 2   |
+| VORON Belted Extruder - Bowden                          | VB-BX-HW-KIT2    | MZBot                        | (see BOM for parts)        | 2   |
+
+### Build Plate  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| Aluminum Tooling Plate MIC-6 9x9x0.25 in                | VE-B-AL-9        | Filafarm (228x228 custom)    |                            | 1   |
+| PEI Sheet 9x9x0.04 in                                   | VE-B-PEI-9       | Filafarm (228x228 custom)    |                            | 1   |
+| 3M 468MP Adhesive 12x12 in                              | VE-B-3M468-12    | Filafarm                     | (included with PEI sheet   | 1   |
+
+### Hardware (KIT4)  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| M5 Cap Socket Screw 10mm                                | VB-HW-CSS-M5-10  | Online-Schrauben.de          | Cap = Linsenkopf           | 36  |
+| M5 Cap Socket Screw 30mm                                | VB-HW-CSS-M5-30  | Online-Schrauben.de          | Cap = Linsenkopf           | 6   |
+| M3 Hex Socket Screw 20mm                                | VB-HW-HSS-M3-20  | Online-Schrauben.de          | Hex = Zylinderkopf         | 9   |
+| M3 Hex Socket Screw 30mm                                | VB-HW-HSS-M3-30  | Online-Schrauben.de          | Hex = Zylinderkopf         | 5   |
+| M3 Hex Socket Screw 40mm                                | VB-HW-HSS-M3-40  | Online-Schrauben.de          | Hex = Zylinderkopf         | 2   |
+| M3 Hex Socket Screw 16mm                                | VB-HW-HSS-M3-16  | Online-Schrauben.de          | Hex = Zylinderkopf         | 19  |
+| M3 Hex Socket Screw 8mm                                 | VB-HW-HSS-M3-8   | Online-Schrauben.de          | Hex = Zylinderkopf         | 25  |
+| M3 Hex Socket Screw 12mm                                | VB-HW-HSS-M3-12  | Online-Schrauben.de          | Hex = Zylinderkopf         | 2   |
+| M4 Cap Socket Screw 6mm                                 | VB-HW-HSS-M4-6   | Online-Schrauben.de          | Cap = Linsenkopf           | 4   |
+| M3 Hex Nut                                              | VB-HW-HN-M3      | Online-Schrauben.de          |                            | 14  |
+| M3 Hex Lock Nut                                         | VB-HW-HLN-M3     | Online-Schrauben.de          |                            | 4   |
+| M5 Hex Nut                                              | VB-HW-HN-M5      | Online-Schrauben.de          |                            | 2   |
+| M5 Washer Steel                                         | VB-HW-WST-M5     | Online-Schrauben.de          |                            | 2   |
+| No. 6 Washer Neoprene                                   | VB-HW-WNP-M3     | eBay(atters153)              | 401059266883               | 16  |
+| M3 Washer Steel                                         | VB-HW-WST-M3     | Online-Schrauben.de          |                            | 4   |
+| Plastics screw No. 1 7/16”                              | VB-HW-PS-1       | Online-Schrauben.de          | I think 2.2 x 10mm         | 4   |
+| Spring 1" L 0.408" OD                                   | VB-HW-SPB-1      | eBay(top-industrieteile)     | 122022700476 (1x 10x 25mm) | 4   |
+| M3 Pressfit Threaded Insert                             | VB-HW-PFTI-M3    | eBay(gewindebohrerde)        | 331691172687               | 3   |
+| Drop-in T Slot Nuts - M5                                | VB-FR-01-TSN2    | eBay(cnc-zubehoer)           | 131647310693               | 36  |
+| Phillips #10-24 5/8” thread-rolling screws (DIN7500)    | VB-FR-01-PTS1    | Online-Schrauben.de          | Gewindefurchend mit Linsenkopf DIN7500| 24  |
+
+### Tools  
+| Description                                             | MZBot Part #     | Supplier                     | Supplier Part # / eBay #   | Qty |
+|---------------------------------------------------------|------------------|------------------------------|----------------------------|-----|
+| Ball-end Allen Wranches                                 |                  | eBay(hotplay_24_de)          | 151952662132               | 1   |
+| SuperLube 21030 Synthetic Lube with PTFE                |                  | Bondis.com                   |                            | 1   |


### PR DESCRIPTION
This BOM allows to source all Voron parts in Germany so it is somewhat applicable to europe as well. All eBay items are selected from German suppliers, so no China shipping.

The only exceptions are:

- No 6 washer neoprene, E3d Chimera kit which is delivered from the UK
- Superlube which is delivered from the Netherlands.
- Ask the supplier of the Z-Axis steppers whether they have european stock, because sometimes they don't and will ship from China instead

Imperial items are replaced by metric ones to the best of my knowledge.

Misumi Bearings are impossible to get so I replaced them by standard (no-name) Bearings. 

Quantities are either equal or more than required.